### PR TITLE
get active (visible) courses only on the 'All courses' tab

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -207,7 +207,7 @@ function attendance_get_user_sessions_log_full($userid, $pageparams) {
 function attendance_get_user_courses_attendances($userid) {
     global $DB;
 
-    $usercourses = enrol_get_users_courses($userid);
+    $usercourses = enrol_get_users_courses($userid, true);
 
     list($usql, $uparams) = $DB->get_in_or_equal(array_keys($usercourses), SQL_PARAMS_NAMED, 'cid0');
 


### PR DESCRIPTION
This is a possible solution to resolve issue 772. The report should only show active (visible) courses and their Attendance sessions.